### PR TITLE
Bump binary minimum version.

### DIFF
--- a/distributed-closure.cabal
+++ b/distributed-closure.cabal
@@ -22,7 +22,7 @@ library
                        Control.Distributed.Closure.Internal
                        Control.Distributed.Closure.TH
   build-depends:       base >=4.8 && <5
-                     , binary >= 0.7.5
+                     , binary >= 0.7.6
                      , bytestring >= 0.10
                      , constraints >= 0.4
                      , template-haskell >= 2.10


### PR DESCRIPTION
The Binary instance for Fingerprint (i.e., StaticKey) appeared in binary-0.7.6.0 .

Hackage page for binary-0.7.5.0 and binary-0.7.6.0:
https://hackage.haskell.org/package/binary-0.7.5.0/docs/Data-Binary.html
https://hackage.haskell.org/package/binary-0.7.6.0/docs/Data-Binary.html

Example failure with a project using binary-0.7.5.0:

```
src/Control/Distributed/Closure/Internal.hs:72:45:
        No instance for (Binary StaticKey) arising from a use of ‘put’
        In the second argument of ‘(>>)’, namely ‘put (staticKey sptr)’
        In the expression: putWord8 0 >> put (staticKey sptr)
        In an equation for ‘putClosure’:
            putClosure (StaticPtr sptr) = putWord8 0 >> put (staticKey sptr)
```
