### PR TITLE
Support the IsStatic type class.

### DIFF
--- a/src/Control/Distributed/Closure/Internal.hs
+++ b/src/Control/Distributed/Closure/Internal.hs
@@ -56,6 +56,11 @@ data Closure a where
   -- Cache the value a closure resolves to.
   Closure :: a -> !(Closure a) -> Closure a
 
+#if __GLASGOW_HASKELL__ >= 800
+instance IsStatic Closure where
+  fromStaticPtr = closure
+#endif
+
 -- Will be obsoleted by https://ghc.haskell.org/trac/ghc/wiki/Typeable. We use
 -- our own datatype instead of Dynamic in order to support dynClosureApply.
 newtype DynClosure = DynClosure Any -- invariant: only values of type Closure.


### PR DESCRIPTION
IsStatic was silently introduced in GHC 8.0.1. It allows overloading
static pointer literals much in the same way string literals are. See
https://phabricator.haskell.org/D1923 for details.