### PR TITLE
Add closure duplication (comonadic operation).

### DIFF
--- a/src/Control/Distributed/Closure.hs
+++ b/src/Control/Distributed/Closure.hs
@@ -24,6 +24,7 @@ module Control.Distributed.Closure
   , cpure
   , cap
   , cmap
+  , cduplicate
     -- * Closure dictionaries
     -- $static-dicts
   , Dict(..)

--- a/src/Control/Distributed/Closure/Internal.hs
+++ b/src/Control/Distributed/Closure/Internal.hs
@@ -137,6 +137,7 @@ unclosure (Ap cf cx) = (unclosure cf) (unclosure cx)
 unclosure (Closure x _) = x
 unclosure (Duplicate x) = x
 
+-- | Turn a closure into a closure of a closure.
 cduplicate :: Closure a -> Closure (Closure a)
 cduplicate = Duplicate
 

--- a/src/Control/Distributed/Closure/Internal.hs
+++ b/src/Control/Distributed/Closure/Internal.hs
@@ -24,6 +24,7 @@ module Control.Distributed.Closure.Internal
   , cpure
   , cap
   , cmap
+  , cduplicate
   ) where
 
 import Data.Binary (Binary(..), Get, Put, decode, encode)
@@ -53,6 +54,7 @@ data Closure a where
   StaticPtr :: !(StaticPtr a) -> Closure a
   Encoded :: !ByteString -> Closure ByteString
   Ap :: !(Closure (a -> b)) -> !(Closure a) -> Closure b
+  Duplicate :: Closure a -> Closure (Closure a)
   -- Cache the value a closure resolves to.
   Closure :: a -> !(Closure a) -> Closure a
 
@@ -79,6 +81,10 @@ dynClosureApply (DynClosure x1) (DynClosure x2) =
       (clos1 :: Closure (a -> b)) -> case unsafeCoerce x2 of
         (clos2 :: Closure a) -> DynClosure $ unsafeCoerce $ Ap clos1 clos2
 
+dynClosureDuplicate :: DynClosure -> DynClosure
+dynClosureDuplicate (DynClosure x) =
+    DynClosure $ unsafeCoerce $ Duplicate $ unsafeCoerce x
+
 -- | Until GHC.StaticPtr can give us a proper TypeRep upon decoding, we have to
 -- pretend that serializing/deserializing a @'Closure' a@ without a @'Typeable'
 -- a@ constraint, i.e. for /any/ @a@, is safe.
@@ -87,6 +93,7 @@ putClosure (StaticPtr sptr) = putWord8 0 >> put (staticKey sptr)
 putClosure (Encoded bs) = putWord8 1 >> put bs
 putClosure (Ap clos1 clos2) = putWord8 2 >> putClosure clos1 >> putClosure clos2
 putClosure (Closure _ clos) = putClosure clos
+putClosure (Duplicate clos) = putWord8 3 >> putClosure clos
 
 getDynClosure :: Get DynClosure
 getDynClosure = getWord8 >>= \case
@@ -95,6 +102,7 @@ getDynClosure = getWord8 >>= \case
            Nothing -> fail $ "Static pointer lookup failed: " ++ show key
     1 -> toDynClosure . Encoded <$> get
     2 -> dynClosureApply <$> getDynClosure <*> getDynClosure
+    3 -> dynClosureDuplicate <$> getDynClosure
     _ -> fail "Binary.get(Closure): unrecognized tag."
 
 #if !MIN_VERSION_binary(0,7,6)
@@ -127,6 +135,10 @@ unclosure (StaticPtr sptr) = deRefStaticPtr sptr
 unclosure (Encoded x) = x
 unclosure (Ap cf cx) = (unclosure cf) (unclosure cx)
 unclosure (Closure x _) = x
+unclosure (Duplicate x) = x
+
+cduplicate :: Closure a -> Closure (Closure a)
+cduplicate = Duplicate
 
 decodeD :: Dict (Serializable a) -> ByteString -> a
 decodeD Dict = decode

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -36,6 +36,10 @@ instance Arbitrary (Closure (Int -> Int)) where
 instance Show (Closure a) where
   show _ = "<closure>"
 
+instance Eq a => Eq (Closure a) where
+  cl1 == cl2 =
+    unclosure cl1 == unclosure cl2
+
 main :: IO ()
 main = hspec $ do
     describe "unclosure" $ do
@@ -43,6 +47,8 @@ main = hspec $ do
         (unclosure . cpure $cdict) x == (x :: Int) &&
         (unclosure . cpure $cdict) y == (y :: Bool) &&
         (unclosure . cpure $cdict) z == (z :: Maybe Int)
+      prop "is inverse to cduplicate" $ \x ->
+        (unclosure . cduplicate) x == (x :: Closure Int)
       it "is inverse to closure" $ do
         (unclosure . closure) (static id) 0 `shouldBe` (0 :: Int)
 


### PR DESCRIPTION
This kind of thing can be defined outside of the library using `cpure`, but
dealing with constraints becomes very painful, so it's very handy to have it
for free.