### PR TITLE
Introduce static class hierarchy.

### DIFF
--- a/distributed-closure.cabal
+++ b/distributed-closure.cabal
@@ -21,6 +21,7 @@ library
   exposed-modules:     Control.Distributed.Closure
                        Control.Distributed.Closure.Internal
                        Control.Distributed.Closure.TH
+                       Control.Distributed.StaticPtr
   build-depends:       base >=4.8 && <5
                      , binary >= 0.7.5
                      , bytestring >= 0.10

--- a/src/Control/Distributed/Closure.hs
+++ b/src/Control/Distributed/Closure.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE StaticPointers #-}
 {-# LANGUAGE UndecidableInstances #-}
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE UndecidableSuperClasses #-}
@@ -30,19 +29,10 @@ module Control.Distributed.Closure
     -- $static-dicts
   , Dict(..)
   , Static(..)
-    -- * Static class hierarchy
-    -- $static-hier
-  , StaticFunctor(..)
-  , StaticApplicative(..)
-  , StaticMonad(..)
-  , staticReturn
-  , StaticComonad(..)
   ) where
 
 import Control.Distributed.Closure.Internal
 import Data.Constraint (Dict(..))
-import Data.Typeable (Typeable)
-import GHC.StaticPtr (StaticPtr, deRefStaticPtr)
 
 -- $static-dicts
 --
@@ -62,64 +52,3 @@ import GHC.StaticPtr (StaticPtr, deRefStaticPtr)
 -- 'Control.Distributed.Closure.TH.withStatic' if it becomes too tedious.
 class c => Static c where
   closureDict :: Closure (Dict c)
-
--- $static-hier
---
--- 'Closure' is not a functor, since we cannot map arbitrary functions over it.
--- But it sure looks like one, and an applicative one at that. What we can do is
--- map /static pointers to/ arbitrary functions over it. 'Closure' is not just
--- an applicative functor, it's also a monad, as well as a comonad, if again we
--- limit the function space to those functions that can be statically pointed
--- to.
---
--- In fact an entire hierarchy of classes mirroring the standard classes can be
--- defined, where the only difference lies in the fact that all pure values'
--- types appearing in negative position must be a proof of /static/-ness. That
--- is, a function cannot in general produce a closure if the only argument /is
--- not/ static (@a -> 'Closure' a@ won't work), but conversely a function cannot
--- produce anything that /is/ static given only a closure (@'Closure' a ->
--- StaticPtr a@ won't work).
-
-class Typeable f => StaticFunctor f where
-  staticMap :: (Typeable a, Typeable b) => StaticPtr (a -> b) -> f a -> f b
-
-instance StaticFunctor Closure where
-  staticMap sf = cap (closure sf)
-
-class StaticFunctor f => StaticApplicative f where
-  staticPure :: Typeable a => StaticPtr a -> f a
-  staticAp :: (Typeable a, Typeable b) => f (a -> b) -> f a -> f b
-
-instance StaticApplicative Closure where
-  staticPure = closure
-  staticAp = cap
-
-class StaticApplicative m => StaticMonad m where
-  staticBind :: (Typeable a, Typeable b) => m a -> StaticPtr (a -> m b) -> m b
-  staticBind m k = staticJoin (staticMap k m)
-
-  staticJoin :: Typeable a => m (m a) -> m a
-  staticJoin m = m `staticBind` static id
-
-  {-# MINIMAL staticBind | staticJoin #-}
-
-staticReturn :: (StaticMonad m, Typeable a) => StaticPtr a -> m a
-staticReturn = staticPure
-
-instance StaticMonad Closure where
-  staticBind m sk = deRefStaticPtr sk (unclosure m)
-
-class StaticFunctor w => StaticComonad w where
-  staticExtract :: w a -> a
-
-  staticDuplicate :: Typeable a => w a -> w (w a)
-  staticDuplicate = staticExtend (static id)
-
-  staticExtend :: (Typeable a, Typeable b) => StaticPtr (w a -> b) -> w a -> w b
-  staticExtend sf = staticMap sf . staticDuplicate
-
-  {-# MINIMAL staticExtract, (staticDuplicate | staticExtend) #-}
-
-instance StaticComonad Closure where
-  staticExtract = unclosure
-  staticDuplicate = cduplicate

--- a/src/Control/Distributed/Closure.hs
+++ b/src/Control/Distributed/Closure.hs
@@ -24,6 +24,7 @@ module Control.Distributed.Closure
   , cpure
   , cap
   , cmap
+  , cduplicate
     -- * Closure dictionaries
     -- $static-dicts
   , Dict(..)

--- a/src/Control/Distributed/Closure.hs
+++ b/src/Control/Distributed/Closure.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE StaticPointers #-}
 {-# LANGUAGE UndecidableInstances #-}
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE UndecidableSuperClasses #-}
@@ -29,10 +30,19 @@ module Control.Distributed.Closure
     -- $static-dicts
   , Dict(..)
   , Static(..)
+    -- * Static class hierarchy
+    -- $static-hier
+  , StaticFunctor(..)
+  , StaticApplicative(..)
+  , StaticMonad(..)
+  , staticReturn
+  , StaticComonad(..)
   ) where
 
 import Control.Distributed.Closure.Internal
 import Data.Constraint (Dict(..))
+import Data.Typeable (Typeable)
+import GHC.StaticPtr (StaticPtr, deRefStaticPtr)
 
 -- $static-dicts
 --
@@ -52,3 +62,64 @@ import Data.Constraint (Dict(..))
 -- 'Control.Distributed.Closure.TH.withStatic' if it becomes too tedious.
 class c => Static c where
   closureDict :: Closure (Dict c)
+
+-- $static-hier
+--
+-- 'Closure' is not a functor, since we cannot map arbitrary functions over it.
+-- But it sure looks like one, and an applicative one at that. What we can do is
+-- map /static pointers to/ arbitrary functions over it. 'Closure' is not just
+-- an applicative functor, it's also a monad, as well as a comonad, if again we
+-- limit the function space to those functions that can be statically pointed
+-- to.
+--
+-- In fact an entire hierarchy of classes mirroring the standard classes can be
+-- defined, where the only difference lies in the fact that all pure values'
+-- types appearing in negative position must be a proof of /static/-ness. That
+-- is, a function cannot in general produce a closure if the only argument /is
+-- not/ static (@a -> 'Closure' a@ won't work), but conversely a function cannot
+-- produce anything that /is/ static given only a closure (@'Closure' a ->
+-- StaticPtr a@ won't work).
+
+class Typeable f => StaticFunctor f where
+  staticMap :: (Typeable a, Typeable b) => StaticPtr (a -> b) -> f a -> f b
+
+instance StaticFunctor Closure where
+  staticMap sf = cap (closure sf)
+
+class StaticFunctor f => StaticApplicative f where
+  staticPure :: Typeable a => StaticPtr a -> f a
+  staticAp :: (Typeable a, Typeable b) => f (a -> b) -> f a -> f b
+
+instance StaticApplicative Closure where
+  staticPure = closure
+  staticAp = cap
+
+class StaticApplicative m => StaticMonad m where
+  staticBind :: (Typeable a, Typeable b) => m a -> StaticPtr (a -> m b) -> m b
+  staticBind m k = staticJoin (staticMap k m)
+
+  staticJoin :: Typeable a => m (m a) -> m a
+  staticJoin m = m `staticBind` static id
+
+  {-# MINIMAL staticBind | staticJoin #-}
+
+staticReturn :: (StaticMonad m, Typeable a) => StaticPtr a -> m a
+staticReturn = staticPure
+
+instance StaticMonad Closure where
+  staticBind m sk = deRefStaticPtr sk (unclosure m)
+
+class StaticFunctor w => StaticComonad w where
+  staticExtract :: w a -> a
+
+  staticDuplicate :: Typeable a => w a -> w (w a)
+  staticDuplicate = staticExtend (static id)
+
+  staticExtend :: (Typeable a, Typeable b) => StaticPtr (w a -> b) -> w a -> w b
+  staticExtend sf = staticMap sf . staticDuplicate
+
+  {-# MINIMAL staticExtract, (staticDuplicate | staticExtend) #-}
+
+instance StaticComonad Closure where
+  staticExtract = unclosure
+  staticDuplicate = cduplicate

--- a/src/Control/Distributed/Closure/Internal.hs
+++ b/src/Control/Distributed/Closure/Internal.hs
@@ -166,4 +166,5 @@ cap closf closx = Ap closf closx
 -- over it. That is, we cannot define 'fmap'. However, we can map a static
 -- pointer to a function over a 'Closure'.
 cmap :: Typeable a => StaticPtr (a -> b) -> Closure a -> Closure b
-cmap sptr = cap (Closure (deRefStaticPtr sptr) (StaticPtr sptr))
+cmap sf = cap (closure sf)
+{-# DEPRECATED cmap "Use staticMap instead." #-}

--- a/src/Control/Distributed/Closure/Internal.hs
+++ b/src/Control/Distributed/Closure/Internal.hs
@@ -24,6 +24,7 @@ module Control.Distributed.Closure.Internal
   , cpure
   , cap
   , cmap
+  , cduplicate
   ) where
 
 import Data.Binary (Binary(..), Get, Put, decode, encode)
@@ -53,6 +54,7 @@ data Closure a where
   StaticPtr :: !(StaticPtr a) -> Closure a
   Encoded :: !ByteString -> Closure ByteString
   Ap :: !(Closure (a -> b)) -> !(Closure a) -> Closure b
+  Duplicate :: Closure a -> Closure (Closure a)
   -- Cache the value a closure resolves to.
   Closure :: a -> !(Closure a) -> Closure a
 
@@ -79,6 +81,10 @@ dynClosureApply (DynClosure x1) (DynClosure x2) =
       (clos1 :: Closure (a -> b)) -> case unsafeCoerce x2 of
         (clos2 :: Closure a) -> DynClosure $ unsafeCoerce $ Ap clos1 clos2
 
+dynClosureDuplicate :: DynClosure -> DynClosure
+dynClosureDuplicate (DynClosure x) =
+    DynClosure $ unsafeCoerce $ Duplicate $ unsafeCoerce x
+
 -- | Until GHC.StaticPtr can give us a proper TypeRep upon decoding, we have to
 -- pretend that serializing/deserializing a @'Closure' a@ without a @'Typeable'
 -- a@ constraint, i.e. for /any/ @a@, is safe.
@@ -87,6 +93,7 @@ putClosure (StaticPtr sptr) = putWord8 0 >> put (staticKey sptr)
 putClosure (Encoded bs) = putWord8 1 >> put bs
 putClosure (Ap clos1 clos2) = putWord8 2 >> putClosure clos1 >> putClosure clos2
 putClosure (Closure _ clos) = putClosure clos
+putClosure (Duplicate clos) = putWord8 3 >> putClosure clos
 
 getDynClosure :: Get DynClosure
 getDynClosure = getWord8 >>= \case
@@ -95,6 +102,7 @@ getDynClosure = getWord8 >>= \case
            Nothing -> fail $ "Static pointer lookup failed: " ++ show key
     1 -> toDynClosure . Encoded <$> get
     2 -> dynClosureApply <$> getDynClosure <*> getDynClosure
+    3 -> dynClosureDuplicate <$> getDynClosure
     _ -> fail "Binary.get(Closure): unrecognized tag."
 
 #if !MIN_VERSION_binary(0,7,6)
@@ -127,6 +135,10 @@ unclosure (StaticPtr sptr) = deRefStaticPtr sptr
 unclosure (Encoded x) = x
 unclosure (Ap cf cx) = (unclosure cf) (unclosure cx)
 unclosure (Closure x _) = x
+unclosure (Duplicate x) = x
+
+cduplicate :: Closure a -> Closure (Closure a)
+cduplicate = Duplicate
 
 decodeD :: Dict (Serializable a) -> ByteString -> a
 decodeD Dict = decode

--- a/src/Control/Distributed/StaticPtr.hs
+++ b/src/Control/Distributed/StaticPtr.hs
@@ -1,0 +1,79 @@
+-- | This module reexports "GHC.StaticPtr" with a few extra utilities.
+
+{-# LANGUAGE StaticPointers #-}
+
+module Control.Distributed.StaticPtr
+  ( module GHC.StaticPtr
+    -- * Static class hierarchy
+    -- $static-hier
+  , StaticFunctor(..)
+  , StaticApplicative(..)
+  , StaticMonad(..)
+  , staticReturn
+  , StaticComonad(..)
+  ) where
+
+import Control.Distributed.Closure.Internal
+import Data.Typeable (Typeable)
+import GHC.StaticPtr
+
+-- $static-hier
+--
+-- 'Closure' is not a functor, since we cannot map arbitrary functions over it.
+-- But it sure looks like one, and an applicative one at that. What we can do is
+-- map /static pointers to/ arbitrary functions over it. 'Closure' is not just
+-- an applicative functor, it's also a monad, as well as a comonad, if again we
+-- limit the function space to those functions that can be statically pointed
+-- to.
+--
+-- In fact an entire hierarchy of classes mirroring the standard classes can be
+-- defined, where the only difference lies in the fact that all pure values'
+-- types appearing in negative position must be a proof of /static/-ness. That
+-- is, a function cannot in general produce a closure if the only argument /is
+-- not/ static (@a -> 'Closure' a@ won't work), but conversely a function cannot
+-- produce anything that /is/ static given only a closure (@'Closure' a ->
+-- StaticPtr a@ won't work).
+
+class Typeable f => StaticFunctor f where
+  staticMap :: (Typeable a, Typeable b) => StaticPtr (a -> b) -> f a -> f b
+
+instance StaticFunctor Closure where
+  staticMap sf = cap (closure sf)
+
+class StaticFunctor f => StaticApplicative f where
+  staticPure :: Typeable a => StaticPtr a -> f a
+  staticAp :: (Typeable a, Typeable b) => f (a -> b) -> f a -> f b
+
+instance StaticApplicative Closure where
+  staticPure = closure
+  staticAp = cap
+
+class StaticApplicative m => StaticMonad m where
+  staticBind :: (Typeable a, Typeable b) => m a -> StaticPtr (a -> m b) -> m b
+  staticBind m k = staticJoin (staticMap k m)
+
+  staticJoin :: Typeable a => m (m a) -> m a
+  staticJoin m = m `staticBind` static id
+
+  {-# MINIMAL staticBind | staticJoin #-}
+
+staticReturn :: (StaticMonad m, Typeable a) => StaticPtr a -> m a
+staticReturn = staticPure
+
+instance StaticMonad Closure where
+  staticBind m sk = deRefStaticPtr sk (unclosure m)
+
+class StaticFunctor w => StaticComonad w where
+  staticExtract :: w a -> a
+
+  staticDuplicate :: Typeable a => w a -> w (w a)
+  staticDuplicate = staticExtend (static id)
+
+  staticExtend :: (Typeable a, Typeable b) => StaticPtr (w a -> b) -> w a -> w b
+  staticExtend sf = staticMap sf . staticDuplicate
+
+  {-# MINIMAL staticExtract, (staticDuplicate | staticExtend) #-}
+
+instance StaticComonad Closure where
+  staticExtract = unclosure
+  staticDuplicate = cduplicate

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -36,6 +36,10 @@ instance Arbitrary (Closure (Int -> Int)) where
 instance Show (Closure a) where
   show _ = "<closure>"
 
+instance Eq a => Eq (Closure a) where
+  cl1 == cl2 =
+    unclosure cl1 == unclosure cl2
+
 main :: IO ()
 main = hspec $ do
     describe "unclosure" $ do
@@ -43,6 +47,8 @@ main = hspec $ do
         (unclosure . cpure $cdict) x == (x :: Int) &&
         (unclosure . cpure $cdict) y == (y :: Bool) &&
         (unclosure . cpure $cdict) z == (z :: Maybe Int)
+      prop "is inverse to cduplicate" $ \x ->
+        (unclosure . cduplicate) x == (x :: Closure Int)
       it "is inverse to closure" $ do
         (unclosure . closure) (static id) 0 `shouldBe` (0 :: Int)
 


### PR DESCRIPTION
`Closure` is not a functor, since we cannot map arbitrary functions
over it. But it sure looks like one, and an applicative one at that.
What we can do is map /static pointers to/ arbitrary functions over
it. `Closure` is not just an applicative functor, it's also a monad,
as well as a comonad, if again we limit the function space to those
functions that can be statically pointed -- to. In fact an entire
hierarchy of classes mirroring the standard classes can be defined,
where the only difference lies in the fact that all pure values' types
appearing in negative position must be a proof of /static/-ness.

Depends on #6.