### PR TITLE
Tests: Add non-trivial generators for Closure

### DIFF
--- a/tests/test.hs
+++ b/tests/test.hs
@@ -205,6 +205,8 @@ instance Arbitrary (Closure (Int -> Int)) where
 instance Show (Closure a) where
   show _ = "<closure>"
 
+-- | Extensional equality on closures (/i.e./ closures are equal if they
+-- represent equal values)
 instance Eq a => Eq (Closure a) where
   cl1 == cl2 =
     unclosure cl1 == unclosure cl2
@@ -229,11 +231,11 @@ main = hspec $ do
       prop "composition" $ \(u :: Closure (Int -> Int))
                             (v :: Closure (Int -> Int))
                             (w :: Closure Int) ->
-        unclosure (closure (static (.)) `cap` u `cap` v `cap` w) ==
-        unclosure (u `cap` (v `cap` w))
+        closure (static (.)) `cap` u `cap` v `cap` w ==
+        u `cap` (v `cap` w)
       prop "homomorphism" $ \(f :: Closure (Int -> Int)) x ->
         unclosure (f `cap` x) == (unclosure f) (unclosure x)
 
     describe "serialization" $ do
       prop "decode is left inverse to encode" $ \v ->
-          unclosure ((decode . encode) v) == unclosure (v :: Closure Int)
+          (decode . encode) v == (v :: Closure Int)

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -205,6 +205,9 @@ instance Arbitrary (Closure (Int -> Int)) where
 instance Show (Closure a) where
   show _ = "<closure>"
 
+instance Show (StaticPtr a) where
+  show _ = "<static>"
+
 -- | Extensional equality on closures (/i.e./ closures are equal if they
 -- represent equal values)
 instance Eq a => Eq (Closure a) where
@@ -222,9 +225,11 @@ main = hspec $ do
         (unclosure . cpure $cdict) z == (z :: Maybe Int)
       prop "is inverse to cduplicate" $ \x ->
         (unclosure . cduplicate) x == (x :: Closure Int)
-      it "is inverse to closure" $ do
-        (unclosure . closure) (static id) 0 `shouldBe` (0 :: Int)
-
+      prop "is inverse to closure of id" $ \(x :: Int) ->
+        (unclosure . closure) (static id) x == x
+      prop "is inverse to closure" $ \(f :: StaticPtr (Int -> Int))
+                                      (x :: Int) ->
+        (unclosure . closure) f x == deRefStaticPtr f x
     describe "laws" $ do
       prop "identity" $ \(v :: Closure Int) ->
         unclosure (static id `cap` v) == id (unclosure v)

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StaticPointers #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -11,6 +12,9 @@ module Main where
 import Control.Distributed.Closure
 import Control.Distributed.Closure.TH
 import Data.Binary
+import Data.Bool (bool)
+import Data.Typeable
+import GHC.StaticPtr
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
@@ -23,15 +27,180 @@ withStatic [d|
   instance (Eq a, Show a) => Eq (T a) where (==) = undefined
   |]
 
+-- * Basic generators (parameterized by size)
+
+genPure :: forall a. (Static (Serializable a), Arbitrary a) => Int -> Gen (Closure a)
+genPure i =
+    cpure (closureDict :: Closure (Dict (Serializable a))) <$>
+      resize (max 0 (i-1)) arbitrary
+
+genStatic :: Arbitrary (StaticPtr a) => Int -> Gen (Closure a)
+-- static pointers are considered to contribute 0 to the size, hence ignore the
+-- size parameter.
+genStatic _i = closure <$> arbitrary
+
+data Type a where
+  TInt :: Type Int
+  TBool :: Type Bool
+
+instance Static (Serializable Int) where
+  closureDict = static Dict
+
+instance Static (Serializable Bool) where
+  closureDict = static Dict
+
+data AType where AType :: Typeable a => Type a -> AType
+
+instance Arbitrary (AType) where
+  arbitrary =
+      elements [ AType TInt, AType TBool ]
+
+data Sig a where
+  Zero :: Type a -> Sig a
+  One :: Type a -> Type b -> Sig (a->b)
+  Two :: Type a -> Type b -> Type c -> Sig (a->b->c)
+
+push :: Type a -> Sig b -> Maybe (Sig (a -> b))
+push a (Zero b) = Just $ One a b
+push a (One b c) = Just $ Two a b c
+push _ (Two _ _ _) = Nothing
+
+genSimple :: Sig a -> Int -> Gen (Closure a)
+genSimple (Zero TInt) = genPure
+genSimple (Zero TBool) = genPure
+genSimple (One TInt TInt) = genStatic
+genSimple (One TBool TInt) = genStatic
+genSimple (One TInt TBool) = genStatic
+genSimple (One TBool TBool) = genStatic
+genSimple (Two TInt TInt TInt) = genStatic
+genSimple (Two TBool TInt TInt) = genStatic
+genSimple (Two TInt TBool TInt) = genStatic
+genSimple (Two TBool TBool TInt) = genStatic
+genSimple (Two TInt TInt TBool) = genStatic
+genSimple (Two TBool TInt TBool) = genStatic
+genSimple (Two TInt TBool TBool) = genStatic
+genSimple (Two TBool TBool TBool) = genStatic
+
+genClosure :: Sig a -> Int -> Gen (Closure a)
+genClosure sig size | size < 10 =
+    genSimple sig size
+genClosure sig size = do
+    stop <- frequency [(2, return True), (1, return False)]
+    if stop then
+      genSimple sig size
+    else do
+      let upper = div size 3
+          lower = max 0 (size - 1 - upper)
+      AType pivot <- arbitrary
+      case push pivot sig of
+        Nothing -> genSimple sig size
+        Just sig' -> do
+          -- if the @size@ is big enough, then 1/3 of the time, if we can extend
+          -- the signature, build a closure with @cap@
+          function <- genClosure sig' upper
+          argument <- genClosure (Zero pivot) lower
+          return $ function `cap` argument
+
+-- * Generating static pointers
+--
+-- Must be from explicit lists since static pointers are, well, static. The
+-- combinatorics is unpleasant.
+
+instance Arbitrary (StaticPtr (Int -> Int)) where
+  arbitrary =
+      elements
+        [ static id
+        , static pred
+        , static succ
+        , static (3*)
+        ]
+
+instance Arbitrary (StaticPtr (Bool -> Int)) where
+  arbitrary =
+      elements
+       [ static (bool 0 1)
+       , static (bool 57 42)]
+
+instance Arbitrary (StaticPtr (Int -> Bool)) where
+  arbitrary =
+      elements
+        [ static (== 0)
+        , static (<= 0)
+        , static (> 0)
+        ]
+
+instance Arbitrary (StaticPtr (Bool -> Bool)) where
+  arbitrary =
+    elements
+      [ static id
+      , static not ]
+
+instance Arbitrary (StaticPtr (Int -> Int -> Int)) where
+  arbitrary =
+      elements
+        [ static const
+        , static (+)
+        , static (*)
+        , static (-)
+        , static (\x y -> 2*x + y)
+        ]
+
+instance Arbitrary (StaticPtr (Bool -> Int -> Int)) where
+  arbitrary =
+    elements
+      [ static (\b n -> if b then n else -n)
+      , static (flip const)
+      ]
+
+instance Arbitrary (StaticPtr (Int -> Bool -> Int)) where
+  arbitrary =
+    elements
+      [ static const
+      , static (bool 0)
+      ]
+
+instance Arbitrary (StaticPtr (Bool -> Bool -> Int)) where
+  arbitrary =
+    elements
+      [ static (\x y -> bool 0 1 (x&&y))
+      , static (\x y -> bool 57 42 (x||y))
+      ]
+
+instance Arbitrary (StaticPtr (Int -> Int -> Bool)) where
+  arbitrary =
+    elements
+      [ static (==)
+      , static (>=)
+      , static (<)
+      ]
+
+instance Arbitrary (StaticPtr (Bool -> Int -> Bool)) where
+  arbitrary =
+    elements
+      [ static const
+      , static (\b n -> b && (n >= 0))
+      , static (\b n -> b || (n < 0))
+      ]
+
+instance Arbitrary (StaticPtr (Int -> Bool -> Bool)) where
+  arbitrary =
+    elements
+      [ static (flip const)
+      , static (\n b -> if b then n >=0 else n < 0)]
+
+instance Arbitrary (StaticPtr (Bool -> Bool -> Bool)) where
+  arbitrary =
+    elements
+      [ static (&&)
+      , static (||)]
+
+-- * Instances
+
 instance Arbitrary (Closure Int) where
-  arbitrary = cpure $cdict <$> elements [0..4]
+  arbitrary = sized $ genClosure (Zero TInt)
 
 instance Arbitrary (Closure (Int -> Int)) where
-  arbitrary =
-      elements [ closure (static id)
-               , closure (static pred)
-               , closure (static succ)
-               ]
+  arbitrary = sized $ genClosure (One TInt TInt)
 
 instance Show (Closure a) where
   show _ = "<closure>"
@@ -39,6 +208,8 @@ instance Show (Closure a) where
 instance Eq a => Eq (Closure a) where
   cl1 == cl2 =
     unclosure cl1 == unclosure cl2
+
+-- * Tests
 
 main :: IO ()
 main = hspec $ do

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -225,7 +225,7 @@ main = hspec $ do
 
     describe "laws" $ do
       prop "identity" $ \(v :: Closure Int) ->
-        unclosure (closure (static id) `cap` v) == id (unclosure v)
+        unclosure (static id `cap` v) == id (unclosure v)
       prop "composition" $ \(u :: Closure (Int -> Int))
                             (v :: Closure (Int -> Int))
                             (w :: Closure Int) ->


### PR DESCRIPTION
[Also took the opportunity of minor clean-ups: removed `closure $ static foo` because `IsStatic` works now, and used an `Eq` instance for `Closure` for clarity]

The tests themselves are not much changed (I just generalised one or two).

Having an actual generator was rather painful because we need a list of functions for basic static pointers. This creates a significant combinatorics, therefore I considered only two base types, and function with maximum 3 arguments.

The generators are a bit large. Maybe we want to move the test above the generators, or even move the generators to another file.

When this is merged, I'll sleep a little better at night, knowing that the tests have a more reasonable chance to catch errors.