### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

One of my company's projects uses this repo as a git submodule, but whenever we build, it creates the `.stack-work/` directory, marking the submodule as dirty. 