### PR TITLE
Only lift 'Closure's on 'staticPure'

### DIFF
--- a/src/Control/Applicative/Static.hs
+++ b/src/Control/Applicative/Static.hs
@@ -20,7 +20,10 @@ class StaticFunctor f => StaticApply f where
     -> f b
 
 class StaticApply f => StaticApplicative f where
-  staticPure :: Typeable a => a -> f a
+  staticPure :: Typeable a => Closure a -> f a
 
 instance StaticApply Closure where
   staticApply = cap
+
+instance StaticApplicative Closure where
+  staticPure = id

--- a/src/Control/Monad/Static.hs
+++ b/src/Control/Monad/Static.hs
@@ -36,7 +36,7 @@ class StaticApply m => StaticBind m where
 class (StaticApplicative m, StaticBind m) => StaticMonad m
 instance (StaticApplicative m, StaticBind m) => StaticMonad m
 
-staticReturn :: (StaticApplicative m, Typeable a) => a -> m a
+staticReturn :: (StaticApplicative m, Typeable a) => Closure a -> m a
 staticReturn = staticPure
 
 instance StaticBind Closure where


### PR DESCRIPTION
Closes #21

This PR changes the definition of `staticPure` to only accept 'Closure's
instead of pure values; so the instance can be used when the value has
to be serialized.

This causes the API to be a bit more restrictive, however I did not see
any uses of `StaticApplicative` on reverse dependencies of this library
(`inline-java` related libraries and `sparkle`).

Also, it turns out that with this change we can also implement
`StaticApplicative` instance for `Closure` trivially. So this PR also
includes this change.